### PR TITLE
Geometry can be scanned from string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
+  - 1.7
+  - tip
 
 after_script:
   - FIXED=$(go vet ./... | wc -l); if [ $FIXED -gt 0 ]; then echo "go vet - $FIXED issues(s), please fix." && exit 2; fi

--- a/geometry.go
+++ b/geometry.go
@@ -159,8 +159,14 @@ func (g *Geometry) UnmarshalJSON(data []byte) error {
 // The columns must be received as GeoJSON Geometry.
 // When using PostGIS a spatial column would need to be wrapped in ST_AsGeoJSON.
 func (g *Geometry) Scan(value interface{}) error {
-	data, ok := value.([]byte)
-	if !ok {
+	var data []byte
+
+	switch value.(type) {
+	case string:
+		data = []byte(value.(string))
+	case []byte:
+		data = value.([]byte)
+	default:
 		return errors.New("unable to parse this type into geojson")
 	}
 

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -263,24 +263,47 @@ func TestUnmarshalGeometryCollection(t *testing.T) {
 	}
 }
 
-func TestGeometryScan(t *testing.T) {
+func TestGeometryScanFail(t *testing.T) {
 	g := &Geometry{}
 
 	err := g.Scan(123)
 	if err == nil {
 		t.Errorf("should return error if not the correct data type")
 	}
+}
 
-	err = g.Scan([]byte(`{"type":"Point","coordinates":[-93.787988,32.392335]}`))
-	if err != nil {
-		t.Fatalf("should parse without error, got %v", err)
+func TestGeometryScan(t *testing.T) {
+	cases := []struct {
+		name  string
+		value interface{}
+	}{
+		{
+			name:  "Scan from bytes",
+			value: []byte(`{"type":"Point","coordinates":[-93.787988,32.392335]}`),
+		},
+		{
+			name:  "Scan from string",
+			value: `{"type":"Point","coordinates":[-93.787988,32.392335]}`,
+		},
 	}
 
-	if !g.IsPoint() {
-		t.Errorf("should be point, but got %v", g)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &Geometry{}
+
+			err := g.Scan(tc.value)
+			if err != nil {
+				t.Fatalf("should parse without error, got %v", err)
+			}
+
+			if !g.IsPoint() {
+				t.Errorf("should be point, but got %v", g)
+			}
+
+			if g.Point[0] != -93.787988 || g.Point[1] != 32.392335 {
+				t.Errorf("incorrect point data, got %v", g.Point)
+			}
+		})
 	}
 
-	if g.Point[0] != -93.787988 || g.Point[1] != 32.392335 {
-		t.Errorf("incorrect point data, got %v", g.Point)
-	}
 }


### PR DESCRIPTION
Postgre driver returns string, not []byte, so Scan method always return error in this case.