### PR TITLE
Fix JSON int ID handling

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -6,7 +6,7 @@ import (
 
 // A Feature corresponds to GeoJSON feature object
 type Feature struct {
-	ID          string                 `json:"id,omitempty"`
+	ID          json.Number            `json:"id,omitempty"`
 	Type        string                 `json:"type"`
 	BoundingBox []float64              `json:"bbox,omitempty"`
 	Geometry    *Geometry              `json:"geometry"`


### PR DESCRIPTION
Parsin JSON like
`{
      "type" : "Feature",
      "id" : 137,
...
}` fails currently
ESRI ArcGIS REST seems to create this kind of GeoJSON. 