### PR TITLE
Feature.ID -> interface{}

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -6,7 +6,7 @@ import (
 
 // A Feature corresponds to GeoJSON feature object
 type Feature struct {
-	ID          json.Number            `json:"id,omitempty"`
+	ID          interface{}            `json:"id,omitempty"`
 	Type        string                 `json:"type"`
 	BoundingBox []float64              `json:"bbox,omitempty"`
 	Geometry    *Geometry              `json:"geometry"`

--- a/feature_test.go
+++ b/feature_test.go
@@ -47,6 +47,34 @@ func TestUnmarshalFeature(t *testing.T) {
 	}
 }
 
+func TestMarshalFeatureID(t *testing.T) {
+	f := &Feature{
+		ID: "asdf",
+	}
+
+	data, err := f.MarshalJSON()
+	if err != nil {
+		t.Fatalf("should marshal, %v", err)
+	}
+
+	if !bytes.Equal(data, []byte(`{"id":"asdf","type":"Feature","geometry":null,"properties":null}`)) {
+		t.Errorf("data not correct")
+		t.Logf("%v", string(data))
+	}
+
+	f.ID = 123
+	data, err = f.MarshalJSON()
+	if err != nil {
+		t.Fatalf("should marshal, %v", err)
+
+	}
+
+	if !bytes.Equal(data, []byte(`{"id":123,"type":"Feature","geometry":null,"properties":null}`)) {
+		t.Errorf("data not correct")
+		t.Logf("%v", string(data))
+	}
+}
+
 func TestUnmarshalFeatureID(t *testing.T) {
 	rawJSON := `
 	  { "type": "Feature",
@@ -59,8 +87,8 @@ func TestUnmarshalFeatureID(t *testing.T) {
 		t.Fatalf("should unmarshal feature without issue, err %v", err)
 	}
 
-	if v, err := f.ID.Int64(); v != 123 {
-		t.Errorf("should parse id as number, got %d %v", v, err)
+	if v, ok := f.ID.(float64); !ok || v != 123 {
+		t.Errorf("should parse id as number, got %T %f", f.ID, v)
 	}
 
 	rawJSON = `
@@ -74,7 +102,7 @@ func TestUnmarshalFeatureID(t *testing.T) {
 		t.Fatalf("should unmarshal feature without issue, err %v", err)
 	}
 
-	if v := f.ID.String(); v != "abcd" {
-		t.Errorf("should parse id as string, got %s", v)
+	if v, ok := f.ID.(string); !ok || v != "abcd" {
+		t.Errorf("should parse id as string, got %T %s", f.ID, v)
 	}
 }


### PR DESCRIPTION
This fixes an issue brought up by @mikhailswift, @colek42 and @nlacey on https://github.com/paulmach/go.geojson/pull/4 (thank you).

An ID can be either a string or a number. In order to support both
marshalling and unmarshalling of those types changing ID to a generic
interface type. 

The user will then need to call something like `f.ID.(float64)` or `f.ID.(string)` to get the value they need. This is consistent with how feature properties are handled.