### PR TITLE
MarshalJSON is now picked by json.Marshal when provided with a value

### DIFF
--- a/feature.go
+++ b/feature.go
@@ -62,14 +62,7 @@ func NewCollectionFeature(geometries ...*Geometry) *Feature {
 // It will handle the encoding of all the child geometries.
 // Alternately one can call json.Marshal(f) directly for the same result.
 func (f Feature) MarshalJSON() ([]byte, error) {
-	type feature struct {
-		ID          interface{}            `json:"id,omitempty"`
-		Type        string                 `json:"type"`
-		BoundingBox []float64              `json:"bbox,omitempty"`
-		Geometry    *Geometry              `json:"geometry"`
-		Properties  map[string]interface{} `json:"properties"`
-		CRS         map[string]interface{} `json:"crs,omitempty"`
-	}
+	type feature Feature
 
 	fea := &feature{
 		ID:       f.ID,

--- a/feature.go
+++ b/feature.go
@@ -61,13 +61,33 @@ func NewCollectionFeature(geometries ...*Geometry) *Feature {
 // MarshalJSON converts the feature object into the proper JSON.
 // It will handle the encoding of all the child geometries.
 // Alternately one can call json.Marshal(f) directly for the same result.
-func (f *Feature) MarshalJSON() ([]byte, error) {
-	f.Type = "Feature"
-	if len(f.Properties) == 0 {
-		f.Properties = nil
+func (f Feature) MarshalJSON() ([]byte, error) {
+	type feature struct {
+		ID          interface{}            `json:"id,omitempty"`
+		Type        string                 `json:"type"`
+		BoundingBox []float64              `json:"bbox,omitempty"`
+		Geometry    *Geometry              `json:"geometry"`
+		Properties  map[string]interface{} `json:"properties"`
+		CRS         map[string]interface{} `json:"crs,omitempty"`
 	}
 
-	return json.Marshal(*f)
+	fea := &feature{
+		ID:       f.ID,
+		Type:     "Feature",
+		Geometry: f.Geometry,
+	}
+
+	if f.BoundingBox != nil && len(f.BoundingBox) != 0 {
+		fea.BoundingBox = f.BoundingBox
+	}
+	if f.Properties != nil && len(f.Properties) != 0 {
+		fea.Properties = f.Properties
+	}
+	if f.CRS != nil && len(f.CRS) != 0 {
+		fea.CRS = f.CRS
+	}
+
+	return json.Marshal(fea)
 }
 
 // UnmarshalFeature decodes the data into a GeoJSON feature.

--- a/feature_collection.go
+++ b/feature_collection.go
@@ -35,12 +35,7 @@ func (fc *FeatureCollection) AddFeature(feature *Feature) *FeatureCollection {
 // It will handle the encoding of all the child features and geometries.
 // Alternately one can call json.Marshal(fc) directly for the same result.
 func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
-	type featureCollection struct {
-		Type        string                 `json:"type"`
-		BoundingBox []float64              `json:"bbox,omitempty"`
-		Features    []*Feature             `json:"features"`
-		CRS         map[string]interface{} `json:"crs,omitempty"`
-	}
+	type featureCollection FeatureCollection
 
 	fcol := &featureCollection{
 		Type: "FeatureCollection",

--- a/feature_collection.go
+++ b/feature_collection.go
@@ -34,12 +34,32 @@ func (fc *FeatureCollection) AddFeature(feature *Feature) *FeatureCollection {
 // MarshalJSON converts the feature collection object into the proper JSON.
 // It will handle the encoding of all the child features and geometries.
 // Alternately one can call json.Marshal(fc) directly for the same result.
-func (fc *FeatureCollection) MarshalJSON() ([]byte, error) {
-	fc.Type = "FeatureCollection"
-	if fc.Features == nil {
-		fc.Features = make([]*Feature, 0) // GeoJSON requires the feature attribute to be at least []
+func (fc FeatureCollection) MarshalJSON() ([]byte, error) {
+	type featureCollection struct {
+		Type        string                 `json:"type"`
+		BoundingBox []float64              `json:"bbox,omitempty"`
+		Features    []*Feature             `json:"features"`
+		CRS         map[string]interface{} `json:"crs,omitempty"`
 	}
-	return json.Marshal(*fc)
+
+	fcol := &featureCollection{
+		Type: "FeatureCollection",
+	}
+
+	if fc.BoundingBox != nil && len(fc.BoundingBox) != 0 {
+		fcol.BoundingBox = fc.BoundingBox
+	}
+
+	fcol.Features = fc.Features
+	if fcol.Features == nil {
+		fcol.Features = make([]*Feature, 0) // GeoJSON requires the feature attribute to be at least []
+	}
+
+	if fc.CRS != nil && len(fc.CRS) != 0 {
+		fcol.CRS = fc.CRS
+	}
+
+	return json.Marshal(fcol)
 }
 
 // UnmarshalFeatureCollection decodes the data into a GeoJSON feature collection.

--- a/feature_collection_test.go
+++ b/feature_collection_test.go
@@ -2,6 +2,7 @@ package geojson
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -65,7 +66,36 @@ func TestUnmarshalFeatureCollection(t *testing.T) {
 
 func TestFeatureCollectionMarshalJSON(t *testing.T) {
 	fc := NewFeatureCollection()
+	fc.Features = nil
 	blob, err := fc.MarshalJSON()
+
+	if err != nil {
+		t.Fatalf("should marshal to json just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"features":[]`)) {
+		t.Errorf("json should set features object to at least empty array")
+	}
+}
+
+func TestFeatureCollectionMarshal(t *testing.T) {
+	fc := NewFeatureCollection()
+	blob, err := json.Marshal(fc)
+	fc.Features = nil
+
+	if err != nil {
+		t.Fatalf("should marshal to json just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"features":[]`)) {
+		t.Errorf("json should set features object to at least empty array")
+	}
+}
+
+func TestFeatureCollectionMarshalValue(t *testing.T) {
+	fc := NewFeatureCollection()
+	fc.Features = nil
+	blob, err := json.Marshal(*fc)
 
 	if err != nil {
 		t.Fatalf("should marshal to json just fine but got %v", err)

--- a/feature_test.go
+++ b/feature_test.go
@@ -2,6 +2,7 @@ package geojson
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -16,6 +17,32 @@ func TestNewFeature(t *testing.T) {
 func TestFeatureMarshalJSON(t *testing.T) {
 	f := NewFeature(NewPointGeometry([]float64{1, 2}))
 	blob, err := f.MarshalJSON()
+
+	if err != nil {
+		t.Fatalf("should marshal to json just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"properties":null`)) {
+		t.Errorf("json should set properties to null if there are none")
+	}
+}
+
+func TestFeatureMarshal(t *testing.T) {
+	f := NewFeature(NewPointGeometry([]float64{1, 2}))
+	blob, err := json.Marshal(f)
+
+	if err != nil {
+		t.Fatalf("should marshal to json just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"properties":null`)) {
+		t.Errorf("json should set properties to null if there are none")
+	}
+}
+
+func TestFeatureMarshalValue(t *testing.T) {
+	f := NewFeature(NewPointGeometry([]float64{1, 2}))
+	blob, err := json.Marshal(*f)
 
 	if err != nil {
 		t.Fatalf("should marshal to json just fine but got %v", err)

--- a/geometry.go
+++ b/geometry.go
@@ -92,7 +92,7 @@ func NewCollectionGeometry(geometries ...*Geometry) *Geometry {
 
 // MarshalJSON converts the geometry object into the correct JSON.
 // This fulfills the json.Marshaler interface.
-func (g *Geometry) MarshalJSON() ([]byte, error) {
+func (g Geometry) MarshalJSON() ([]byte, error) {
 	// defining a struct here lets us define the order of the JSON elements.
 	type geometry struct {
 		Type        GeometryType           `json:"type"`

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -2,6 +2,7 @@ package geojson
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 )
 
@@ -17,7 +18,41 @@ func TestGeometryMarshalJSONPoint(t *testing.T) {
 		t.Errorf("json should have type Point")
 	}
 
-	if !bytes.Contains(blob, []byte(`[1,2]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[1,2]`)) {
+		t.Errorf("json should marshal coordinates correctly")
+	}
+}
+
+func TestGeometryMarshalPoint(t *testing.T) {
+	g := NewPointGeometry([]float64{1, 2})
+	blob, err := json.Marshal(g)
+
+	if err != nil {
+		t.Fatalf("should json.Marshal just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"type":"Point"`)) {
+		t.Errorf("json should have type Point")
+	}
+
+	if !bytes.Contains(blob, []byte(`"coordinates":[1,2]`)) {
+		t.Errorf("json should marshal coordinates correctly")
+	}
+}
+
+func TestGeometryMarshalPointValue(t *testing.T) {
+	g := NewPointGeometry([]float64{1, 2})
+	blob, err := json.Marshal(*g)
+
+	if err != nil {
+		t.Fatalf("should json.Marshal just fine but got %v", err)
+	}
+
+	if !bytes.Contains(blob, []byte(`"type":"Point"`)) {
+		t.Errorf("json should have type Point")
+	}
+
+	if !bytes.Contains(blob, []byte(`"coordinates":[1,2]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }
@@ -34,7 +69,7 @@ func TestGeometryMarshalJSONMultiPoint(t *testing.T) {
 		t.Errorf("json should have type MultiPoint")
 	}
 
-	if !bytes.Contains(blob, []byte(`[[1,2],[3,4]]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[[1,2],[3,4]]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }
@@ -51,7 +86,7 @@ func TestGeometryMarshalJSONLineString(t *testing.T) {
 		t.Errorf("json should have type LineString")
 	}
 
-	if !bytes.Contains(blob, []byte(`[[1,2],[3,4]]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[[1,2],[3,4]]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }
@@ -71,7 +106,7 @@ func TestGeometryMarshalJSONMultiLineString(t *testing.T) {
 		t.Errorf("json should have type MultiLineString")
 	}
 
-	if !bytes.Contains(blob, []byte(`[[[1,2],[3,4]],[[5,6],[7,8]]]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[[[1,2],[3,4]],[[5,6],[7,8]]]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }
@@ -91,7 +126,7 @@ func TestGeometryMarshalJSONPolygon(t *testing.T) {
 		t.Errorf("json should have type Polygon")
 	}
 
-	if !bytes.Contains(blob, []byte(`[[[1,2],[3,4]],[[5,6],[7,8]]]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[[[1,2],[3,4]],[[5,6],[7,8]]]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }
@@ -116,7 +151,7 @@ func TestGeometryMarshalJSONMultiPolygon(t *testing.T) {
 		t.Errorf("json should have type MultiPolygon")
 	}
 
-	if !bytes.Contains(blob, []byte(`[[[[1,2],[3,4]],[[5,6],[7,8]]],[[[8,7],[6,5]],[[4,3],[2,1]]]]`)) {
+	if !bytes.Contains(blob, []byte(`"coordinates":[[[[1,2],[3,4]],[[5,6],[7,8]]],[[[8,7],[6,5]],[[4,3],[2,1]]]]`)) {
 		t.Errorf("json should marshal coordinates correctly")
 	}
 }


### PR DESCRIPTION
All it took was changing the signature from (x *Type) to (x Type). Added json.Mashal test for both *Type and Type.

This required (current entered infinite loop) to rewrite feature & feature_collection MarshalJSON. It now mirrors geometry’s implementation (doesn’t mutate caller).

Made the tests more stringent.

Signed-off-by: Frédéric Miserey <frederic@none.net>