### PR TITLE
Added a BoundingBox retrieval method to feature

### DIFF
--- a/bbox.go
+++ b/bbox.go
@@ -1,16 +1,15 @@
 package geojson
 
-
 // BoundingBox implementation as per https://tools.ietf.org/html/rfc7946
 // BoundingBox syntax: "bbox": [west, south, east, north]
-// BoundingBox defaults "bbox": [-180.0, -90.0, 180.0, 90.0] 
+// BoundingBox defaults "bbox": [-180.0, -90.0, 180.0, 90.0]
 func BoundingBox_Points(pts [][]float64) []float64 {
 	// setting opposite default values
-	west,south,east,north := 180.0, 90.0, -180.0, -90.0
+	west, south, east, north := 180.0, 90.0, -180.0, -90.0
 
-	for _,pt := range pts {
-		x,y := pt[0],pt[1]
-		// can only be one condition 
+	for _, pt := range pts {
+		x, y := pt[0], pt[1]
+		// can only be one condition
 		// using else if reduces one comparison
 		if x < west {
 			west = x
@@ -24,61 +23,61 @@ func BoundingBox_Points(pts [][]float64) []float64 {
 			north = y
 		}
 	}
-	return []float64{west,south,east,north}
+	return []float64{west, south, east, north}
 }
 
-func Push_Two_BoundingBoxs(bb1 []float64,bb2 []float64) []float64 {
+func Push_Two_BoundingBoxs(bb1 []float64, bb2 []float64) []float64 {
 	// setting opposite default values
-	west,south,east,north := 180.0, 90.0, -180.0, -90.0
+	west, south, east, north := 180.0, 90.0, -180.0, -90.0
 
 	// setting bb1 and bb2
-	west1,south1,east1,north1 := bb1[0],bb1[1],bb1[2],bb1[3]
-	west2,south2,east2,north2 := bb2[0],bb2[1],bb2[2],bb2[3]
+	west1, south1, east1, north1 := bb1[0], bb1[1], bb1[2], bb1[3]
+	west2, south2, east2, north2 := bb2[0], bb2[1], bb2[2], bb2[3]
 
-	// handling west values: min 
+	// handling west values: min
 	if west1 < west2 {
 		west = west1
 	} else {
 		west = west2
 	}
 
-	// handling south values: min 
+	// handling south values: min
 	if south1 < south2 {
 		south = south1
 	} else {
 		south = south2
 	}
 
-	// handling east values: max 
+	// handling east values: max
 	if east1 > east2 {
 		east = east1
 	} else {
 		east = east2
 	}
 
-	// handling east values: max 
+	// handling east values: max
 	if east1 > east2 {
 		east = east1
 	} else {
 		east = east2
 	}
 
-	// handling north values: max 
+	// handling north values: max
 	if north1 > north2 {
 		north = north1
 	} else {
 		north = north2
 	}
 
-	return []float64{west,south,east,north}
+	return []float64{west, south, east, north}
 }
 
-// this functions takes an array of bounding box objects and 
+// this functions takes an array of bounding box objects and
 // pushses them all out
 func Expand_BoundingBoxs(bboxs [][]float64) []float64 {
 	bbox := bboxs[0]
-	for _,temp_bbox := range bboxs[1:] {
-		bbox = Push_Two_BoundingBoxs(bbox,temp_bbox)
+	for _, temp_bbox := range bboxs[1:] {
+		bbox = Push_Two_BoundingBoxs(bbox, temp_bbox)
 	}
 	return bbox
 }
@@ -86,7 +85,7 @@ func Expand_BoundingBoxs(bboxs [][]float64) []float64 {
 // boudning box on a normal point geometry
 // relatively useless
 func BoundingBox_PointGeometry(pt []float64) []float64 {
-	return []float64{pt[0],pt[1],pt[0],pt[1]}
+	return []float64{pt[0], pt[1], pt[0], pt[1]}
 }
 
 // Returns BoundingBox for a MultiPoint
@@ -102,8 +101,8 @@ func BoundingBox_LineStringGeometry(line [][]float64) []float64 {
 // Returns BoundingBox for a MultiLineString
 func BoundingBox_MultiLineStringGeometry(multiline [][][]float64) []float64 {
 	bboxs := [][]float64{}
-	for _,line := range multiline {
-		bboxs = append(bboxs,BoundingBox_Points(line))
+	for _, line := range multiline {
+		bboxs = append(bboxs, BoundingBox_Points(line))
 	}
 	return Expand_BoundingBoxs(bboxs)
 }
@@ -111,8 +110,8 @@ func BoundingBox_MultiLineStringGeometry(multiline [][][]float64) []float64 {
 // Returns BoundingBox for a Polygon
 func BoundingBox_PolygonGeometry(polygon [][][]float64) []float64 {
 	bboxs := [][]float64{}
-	for _,cont := range polygon {
-		bboxs = append(bboxs,BoundingBox_Points(cont))
+	for _, cont := range polygon {
+		bboxs = append(bboxs, BoundingBox_Points(cont))
 	}
 	return Expand_BoundingBoxs(bboxs)
 }
@@ -120,9 +119,9 @@ func BoundingBox_PolygonGeometry(polygon [][][]float64) []float64 {
 // Returns BoundingBox for a Polygon
 func BoundingBox_MultiPolygonGeometry(multipolygon [][][][]float64) []float64 {
 	bboxs := [][]float64{}
-	for _,polygon := range multipolygon {
-		for _,cont := range polygon {
-			bboxs = append(bboxs,BoundingBox_Points(cont))
+	for _, polygon := range multipolygon {
+		for _, cont := range polygon {
+			bboxs = append(bboxs, BoundingBox_Points(cont))
 		}
 	}
 	return Expand_BoundingBoxs(bboxs)
@@ -131,8 +130,8 @@ func BoundingBox_MultiPolygonGeometry(multipolygon [][][][]float64) []float64 {
 // Returns a BoundingBox for a geometry collection
 func BoundingBox_GeometryCollection(gs []*Geometry) []float64 {
 	bboxs := [][]float64{}
-	for _,g := range gs {
-		bboxs = append(bboxs,g.Get_BoundingBox())
+	for _, g := range gs {
+		bboxs = append(bboxs, g.Get_BoundingBox())
 	}
 	return Expand_BoundingBoxs(bboxs)
 }

--- a/bbox.go
+++ b/bbox.go
@@ -55,13 +55,6 @@ func Push_Two_BoundingBoxs(bb1 []float64, bb2 []float64) []float64 {
 		east = east2
 	}
 
-	// handling east values: max
-	if east1 > east2 {
-		east = east1
-	} else {
-		east = east2
-	}
-
 	// handling north values: max
 	if north1 > north2 {
 		north = north1

--- a/bbox.go
+++ b/bbox.go
@@ -1,0 +1,164 @@
+package geojson
+
+
+// BoundingBox implementation as per https://tools.ietf.org/html/rfc7946
+// BoundingBox syntax: "bbox": [west, south, east, north]
+// BoundingBox defaults "bbox": [-180.0, -90.0, 180.0, 90.0] 
+func BoundingBox_Points(pts [][]float64) []float64 {
+	// setting opposite default values
+	west,south,east,north := 180.0, 90.0, -180.0, -90.0
+
+	for _,pt := range pts {
+		x,y := pt[0],pt[1]
+		// can only be one condition 
+		// using else if reduces one comparison
+		if x < west {
+			west = x
+		} else if x > east {
+			east = x
+		}
+
+		if y < south {
+			south = y
+		} else if y > north {
+			north = y
+		}
+	}
+	return []float64{west,south,east,north}
+}
+
+func Push_Two_BoundingBoxs(bb1 []float64,bb2 []float64) []float64 {
+	// setting opposite default values
+	west,south,east,north := 180.0, 90.0, -180.0, -90.0
+
+	// setting bb1 and bb2
+	west1,south1,east1,north1 := bb1[0],bb1[1],bb1[2],bb1[3]
+	west2,south2,east2,north2 := bb2[0],bb2[1],bb2[2],bb2[3]
+
+	// handling west values: min 
+	if west1 < west2 {
+		west = west1
+	} else {
+		west = west2
+	}
+
+	// handling south values: min 
+	if south1 < south2 {
+		south = south1
+	} else {
+		south = south2
+	}
+
+	// handling east values: max 
+	if east1 > east2 {
+		east = east1
+	} else {
+		east = east2
+	}
+
+	// handling east values: max 
+	if east1 > east2 {
+		east = east1
+	} else {
+		east = east2
+	}
+
+	// handling north values: max 
+	if north1 > north2 {
+		north = north1
+	} else {
+		north = north2
+	}
+
+	return []float64{west,south,east,north}
+}
+
+// this functions takes an array of bounding box objects and 
+// pushses them all out
+func Expand_BoundingBoxs(bboxs [][]float64) []float64 {
+	bbox := bboxs[0]
+	for _,temp_bbox := range bboxs[1:] {
+		bbox = Push_Two_BoundingBoxs(bbox,temp_bbox)
+	}
+	return bbox
+}
+
+// boudning box on a normal point geometry
+// relatively useless
+func BoundingBox_PointGeometry(pt []float64) []float64 {
+	return []float64{pt[0],pt[1],pt[0],pt[1]}
+}
+
+// Returns BoundingBox for a MultiPoint
+func BoundingBox_MultiPointGeometry(pts [][]float64) []float64 {
+	return BoundingBox_Points(pts)
+}
+
+// Returns BoundingBox for a LineString
+func BoundingBox_LineStringGeometry(line [][]float64) []float64 {
+	return BoundingBox_Points(line)
+}
+
+// Returns BoundingBox for a MultiLineString
+func BoundingBox_MultiLineStringGeometry(multiline [][][]float64) []float64 {
+	bboxs := [][]float64{}
+	for _,line := range multiline {
+		bboxs = append(bboxs,BoundingBox_Points(line))
+	}
+	return Expand_BoundingBoxs(bboxs)
+}
+
+// Returns BoundingBox for a Polygon
+func BoundingBox_PolygonGeometry(polygon [][][]float64) []float64 {
+	bboxs := [][]float64{}
+	for _,cont := range polygon {
+		bboxs = append(bboxs,BoundingBox_Points(cont))
+	}
+	return Expand_BoundingBoxs(bboxs)
+}
+
+// Returns BoundingBox for a Polygon
+func BoundingBox_MultiPolygonGeometry(multipolygon [][][][]float64) []float64 {
+	bboxs := [][]float64{}
+	for _,polygon := range multipolygon {
+		for _,cont := range polygon {
+			bboxs = append(bboxs,BoundingBox_Points(cont))
+		}
+	}
+	return Expand_BoundingBoxs(bboxs)
+}
+
+// Returns a BoundingBox for a geometry collection
+func BoundingBox_GeometryCollection(gs []*Geometry) []float64 {
+	bboxs := [][]float64{}
+	for _,g := range gs {
+		bboxs = append(bboxs,g.Get_BoundingBox())
+	}
+	return Expand_BoundingBoxs(bboxs)
+}
+
+// retrieves a boundingbox for a given geometry
+func (g *Geometry) Get_BoundingBox() []float64 {
+	switch g.Type {
+	case GeometryPoint:
+		return BoundingBox_PointGeometry(g.Point)
+	case GeometryMultiPoint:
+		return BoundingBox_MultiPointGeometry(g.MultiPoint)
+	case GeometryLineString:
+		return BoundingBox_LineStringGeometry(g.LineString)
+	case GeometryMultiLineString:
+		return BoundingBox_MultiLineStringGeometry(g.MultiLineString)
+	case GeometryPolygon:
+		return BoundingBox_PolygonGeometry(g.Polygon)
+	case GeometryMultiPolygon:
+		return BoundingBox_MultiPolygonGeometry(g.MultiPolygon)
+	case GeometryCollection:
+		return BoundingBox_GeometryCollection(g.Geometries)
+	}
+	return []float64{}
+}
+
+func (feature *Feature) Get_BoundingBox() {
+	bb := feature.Geometry.Get_BoundingBox()
+	feature.BoundingBox = bb
+}

--- a/bbox_test.go
+++ b/bbox_test.go
@@ -1,7 +1,6 @@
-package geojson	
+package geojson
 
 import "testing"
-
 
 func TestBoundingBoxPoint(t *testing.T) {
 	g := NewPointGeometry([]float64{1, 2})
@@ -9,7 +8,7 @@ func TestBoundingBoxPoint(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox Point expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox Point expected: %v, got: %v", expected, value)
 	}
 }
 
@@ -17,12 +16,11 @@ func TestBoundingBoxMultiPoint(t *testing.T) {
 	g := NewMultiPointGeometry([]float64{1, 2}, []float64{3, 4})
 	expected := []float64{1, 2, 3, 4}
 	value := g.Get_BoundingBox()
-	
+
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox MultiPoint expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox MultiPoint expected: %v, got: %v", expected, value)
 	}
 }
-
 
 func TestBoundingBoxLineString(t *testing.T) {
 	g := NewLineStringGeometry([][]float64{{1, 2}, {3, 4}})
@@ -30,10 +28,9 @@ func TestBoundingBoxLineString(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox LineString expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox LineString expected: %v, got: %v", expected, value)
 	}
 }
-
 
 func TestBoundingBoxMultiLineString(t *testing.T) {
 	g := NewMultiLineStringGeometry(
@@ -44,10 +41,9 @@ func TestBoundingBoxMultiLineString(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox MultiLineString expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox MultiLineString expected: %v, got: %v", expected, value)
 	}
 }
-
 
 func TestBoundingBoxPolygon(t *testing.T) {
 	g := NewPolygonGeometry([][][]float64{
@@ -58,7 +54,7 @@ func TestBoundingBoxPolygon(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox Polygon expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox Polygon expected: %v, got: %v", expected, value)
 	}
 }
 
@@ -76,10 +72,9 @@ func TestBoundingBoxMultiPolygon(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox MultiPolygon expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox MultiPolygon expected: %v, got: %v", expected, value)
 	}
 }
-
 
 func TestCollectionGeometry(t *testing.T) {
 	g := NewCollectionGeometry(
@@ -90,6 +85,6 @@ func TestCollectionGeometry(t *testing.T) {
 	value := g.Get_BoundingBox()
 
 	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
-		t.Errorf("BoundingBox Collection expected: %v, got: %v",expected,value)
+		t.Errorf("BoundingBox Collection expected: %v, got: %v", expected, value)
 	}
 }

--- a/bbox_test.go
+++ b/bbox_test.go
@@ -1,0 +1,95 @@
+package geojson	
+
+import "testing"
+
+
+func TestBoundingBoxPoint(t *testing.T) {
+	g := NewPointGeometry([]float64{1, 2})
+	expected := []float64{1, 2, 1, 2}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox Point expected: %v, got: %v",expected,value)
+	}
+}
+
+func TestBoundingBoxMultiPoint(t *testing.T) {
+	g := NewMultiPointGeometry([]float64{1, 2}, []float64{3, 4})
+	expected := []float64{1, 2, 3, 4}
+	value := g.Get_BoundingBox()
+	
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox MultiPoint expected: %v, got: %v",expected,value)
+	}
+}
+
+
+func TestBoundingBoxLineString(t *testing.T) {
+	g := NewLineStringGeometry([][]float64{{1, 2}, {3, 4}})
+	expected := []float64{1, 2, 3, 4}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox LineString expected: %v, got: %v",expected,value)
+	}
+}
+
+
+func TestBoundingBoxMultiLineString(t *testing.T) {
+	g := NewMultiLineStringGeometry(
+		[][]float64{{1, 2}, {3, 4}},
+		[][]float64{{5, 6}, {7, 8}},
+	)
+	expected := []float64{1, 2, 7, 8}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox MultiLineString expected: %v, got: %v",expected,value)
+	}
+}
+
+
+func TestBoundingBoxPolygon(t *testing.T) {
+	g := NewPolygonGeometry([][][]float64{
+		{{1, 2}, {3, 4}},
+		{{5, 6}, {7, 8}},
+	})
+	expected := []float64{1, 2, 7, 8}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox Polygon expected: %v, got: %v",expected,value)
+	}
+}
+
+func TestBoundingBoxMultiPolygon(t *testing.T) {
+	g := NewMultiPolygonGeometry(
+		[][][]float64{
+			{{1, 2}, {3, 4}},
+			{{5, 6}, {7, 8}},
+		},
+		[][][]float64{
+			{{8, 7}, {6, 5}},
+			{{4, 3}, {2, 1}},
+		})
+	expected := []float64{1, 1, 7, 8}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox MultiPolygon expected: %v, got: %v",expected,value)
+	}
+}
+
+
+func TestCollectionGeometry(t *testing.T) {
+	g := NewCollectionGeometry(
+		NewPointGeometry([]float64{1, 2}),
+		NewMultiPointGeometry([]float64{1, 2}, []float64{3, 4}),
+	)
+	expected := []float64{1, 2, 3, 4}
+	value := g.Get_BoundingBox()
+
+	if (expected[0] == value[0] && expected[1] == value[1] && expected[2] == value[2] && expected[3] == value[3]) == false {
+		t.Errorf("BoundingBox Collection expected: %v, got: %v",expected,value)
+	}
+}


### PR DESCRIPTION
Hello!

I added a Get_Boundingbox() method to the Feature structure. I realize this is sort of maybe a little out of the projects scope comparing with the other methods, but only slightly, and I would find it incredibly useful. 

You may ask why mutate the BoundingBox at the feature level? When at the geometry level Get_BoundingBox() returns a BoundingBox ([]float64) rather than mutate the Geometry, this is because if you change both you have the same bounding box in two places which isn't cool for serialization to text, and I thought it would be more useful at the top level of a feature rather than within a geometry (although one could argue it makes more sense there).
 