### PR TITLE
Add implementation driver Value interface

### DIFF
--- a/geometry.go
+++ b/geometry.go
@@ -1,6 +1,7 @@
 package geojson
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -173,8 +174,11 @@ func (g *Geometry) Scan(value interface{}) error {
 	return g.UnmarshalJSON(data)
 }
 
+// Value implements the driver Valuer interface.
+// The columns must be sending as GeoJSON Geometry.
+// When using PostGIS a spatial column would need to be wrapped in ST_AsGeoJSON.
 func (g *Geometry) Value() (driver.Value, error) {
-    return g.MarshalJSON()
+	return g.MarshalJSON()
 }
 
 func decodeGeometry(g *Geometry, object map[string]interface{}) error {

--- a/geometry.go
+++ b/geometry.go
@@ -176,7 +176,7 @@ func (g *Geometry) Scan(value interface{}) error {
 
 // Value implements the driver Valuer interface.
 // The columns must be sending as GeoJSON Geometry.
-// When using PostGIS a spatial column would need to be wrapped in ST_AsGeoJSON.
+// When using PostGIS a spatial column would need to be wrapped in ST_GeomFromGeoJSON.
 func (g *Geometry) Value() (driver.Value, error) {
 	return g.MarshalJSON()
 }

--- a/geometry.go
+++ b/geometry.go
@@ -173,6 +173,10 @@ func (g *Geometry) Scan(value interface{}) error {
 	return g.UnmarshalJSON(data)
 }
 
+func (g *Geometry) Value() (driver.Value, error) {
+    return g.MarshalJSON()
+}
+
 func decodeGeometry(g *Geometry, object map[string]interface{}) error {
 	t, ok := object["type"]
 	if !ok {


### PR DESCRIPTION
Implementation driver.Value interface for correct writing Geometry type into DB. When using PostGIS a spatial column would need to be wrapped in  ST_GeomFromGeoJSON.