### PR TITLE
Marshal Empty Properties as Empty Object

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -49,5 +49,5 @@ func ExampleFeatureCollection_MarshalJSON() {
 	}
 
 	fmt.Printf("%s", string(rawJSON))
-	// Output: {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":null}]}
+	// Output: {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[1,2]},"properties":{}}]}
 }

--- a/feature.go
+++ b/feature.go
@@ -75,6 +75,8 @@ func (f Feature) MarshalJSON() ([]byte, error) {
 	}
 	if f.Properties != nil && len(f.Properties) != 0 {
 		fea.Properties = f.Properties
+	} else {
+		fea.Properties = make(map[string]interface{})
 	}
 	if f.CRS != nil && len(f.CRS) != 0 {
 		fea.CRS = f.CRS

--- a/feature_test.go
+++ b/feature_test.go
@@ -22,8 +22,8 @@ func TestFeatureMarshalJSON(t *testing.T) {
 		t.Fatalf("should marshal to json just fine but got %v", err)
 	}
 
-	if !bytes.Contains(blob, []byte(`"properties":null`)) {
-		t.Errorf("json should set properties to null if there are none")
+	if !bytes.Contains(blob, []byte(`"properties":{}`)) {
+		t.Errorf("json should set properties to empty object if there are none")
 	}
 }
 
@@ -35,8 +35,8 @@ func TestFeatureMarshal(t *testing.T) {
 		t.Fatalf("should marshal to json just fine but got %v", err)
 	}
 
-	if !bytes.Contains(blob, []byte(`"properties":null`)) {
-		t.Errorf("json should set properties to null if there are none")
+	if !bytes.Contains(blob, []byte(`"properties":{}`)) {
+		t.Errorf("json should set properties to empty object if there are none")
 	}
 }
 
@@ -48,8 +48,8 @@ func TestFeatureMarshalValue(t *testing.T) {
 		t.Fatalf("should marshal to json just fine but got %v", err)
 	}
 
-	if !bytes.Contains(blob, []byte(`"properties":null`)) {
-		t.Errorf("json should set properties to null if there are none")
+	if !bytes.Contains(blob, []byte(`"properties":{}`)) {
+		t.Errorf("json should set properties to empty object if there are none")
 	}
 }
 
@@ -89,7 +89,7 @@ func TestMarshalFeatureID(t *testing.T) {
 		t.Fatalf("should marshal, %v", err)
 	}
 
-	if !bytes.Equal(data, []byte(`{"id":"asdf","type":"Feature","geometry":null,"properties":null}`)) {
+	if !bytes.Equal(data, []byte(`{"id":"asdf","type":"Feature","geometry":null,"properties":{}}`)) {
 		t.Errorf("data not correct")
 		t.Logf("%v", string(data))
 	}
@@ -101,7 +101,7 @@ func TestMarshalFeatureID(t *testing.T) {
 
 	}
 
-	if !bytes.Equal(data, []byte(`{"id":123,"type":"Feature","geometry":null,"properties":null}`)) {
+	if !bytes.Equal(data, []byte(`{"id":123,"type":"Feature","geometry":null,"properties":{}}`)) {
 		t.Errorf("data not correct")
 		t.Logf("%v", string(data))
 	}


### PR DESCRIPTION
Marshal empty properties to an empty object rather than null.  Both are valid GeoJSON per RFC 7946, but null properties doesn't work with geojson.io (at the moment).  See
https://github.com/mapbox/geojson.io/issues/610