### PR TITLE
go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/paulmach/go.geojson
+
+go 1.18


### PR DESCRIPTION
While Go is [backwards compatible with non-module repsitories](https://go.dev/ref/mod#non-module-compat), this updates to provide go module compatability. I noticed this while evaluating using this package.